### PR TITLE
TLS and `tracing` support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ tokio-openssl = { version = "0.6.3", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.18.1", features = ["net", "io-util", "rt", "macros"] }
+tokio-test = "0.4.2"
 
 [[example]]
 name = "tls_sender"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,4 @@ lazy_static = "1.4"
 byteorder = "1.4"
 thiserror = "1.0.31"
 tokio = { version = "1.18", optional = true, features = ["net", "io-util"] }
+tracing = { version = "0.1", optional = true, features = ["log", "std"], default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,18 @@ readme = "README.md"
 license = "MIT"
 edition = "2021"
 
+[package.metadata."docs.rs"]
+features = [
+	"async_tokio",
+	"tls_openssl",
+	"tls_openssl_tokio",
+	"clap",
+]
+
 [features]
 async_tokio = ["tokio"]
-_tls_common = ["x509-certificate", "derive_builder"]
-tls_rustls = ["_tls_common", "rustls", "rustls-pemfile", "rustls-native-certs"]
+_tls_common = ["derive_builder"]
+tls_rustls = ["_tls_common", "rustls", "rustls-pemfile", "rustls-native-certs", "x509-certificate"]
 tls_openssl = ["_tls_common", "openssl", "openssl-errors", "hex"]
 tls_rustls_tokio = ["tokio-rustls"]
 tls_openssl_tokio = ["tokio-openssl"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,11 @@ edition = "2021"
 
 [features]
 async_tokio = ["tokio"]
-async_tls = ["tokio-rustls"]
-tls = ["rustls", "rustls-pemfile", "rustls-native-certs", "x509-certificate", "derive_builder"]
+_tls_common = ["x509-certificate", "derive_builder"]
+tls_rustls = ["_tls_common", "rustls", "rustls-pemfile", "rustls-native-certs"]
+tls_openssl = ["_tls_common", "openssl", "openssl-errors", "hex"]
+tls_rustls_tokio = ["tokio-rustls"]
+tls_openssl_tokio = ["tokio-openssl"]
 
 [dependencies]
 serde  = { version = "1", features = ["derive"] }
@@ -32,14 +35,18 @@ rustls-pemfile = { version = "1.0.0", optional = true }
 rustls-native-certs = { version = "0.6.2", optional = true }
 x509-certificate = { version = "0.13.0", optional = true }
 tokio-rustls = { version = "0.23.4", optional = true }
+openssl = { version = "0.10.40", optional = true }
+hex = { version = "0.4.3", optional = true }
+openssl-errors = { version = "0.2.0", optional = true }
+tokio-openssl = { version = "0.6.3", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.18.1", features = ["net", "io-util", "rt", "macros"] }
 
 [[example]]
 name = "tls_sender"
-required-features = ["tls", "clap"]
+required-features = ["_tls_common", "clap"]
 
 [[example]]
 name = "tls_sender_async"
-required-features = ["tls", "clap", "async_tokio", "async_tls"]
+required-features = ["_tls_common", "clap", "async_tokio"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ edition = "2021"
 
 [features]
 async_tokio = ["tokio"]
+async_tls = ["tokio-rustls"]
+tls = ["rustls", "rustls-pemfile", "rustls-native-certs", "x509-certificate", "derive_builder"]
 
 [dependencies]
 serde  = { version = "1", features = ["derive"] }
@@ -23,3 +25,21 @@ byteorder = "1.4"
 thiserror = "1.0.31"
 tokio = { version = "1.18", optional = true, features = ["net", "io-util"] }
 tracing = { version = "0.1", optional = true, features = ["log", "std"], default-features = false }
+clap = { version = "3.1.17", optional = true, features = ["std", "derive"], default-features = false }
+derive_builder = { version = "0.11.2", optional = true }
+rustls = { version = "0.20.4", features = ["dangerous_configuration"], optional = true }
+rustls-pemfile = { version = "1.0.0", optional = true }
+rustls-native-certs = { version = "0.6.2", optional = true }
+x509-certificate = { version = "0.13.0", optional = true }
+tokio-rustls = { version = "0.23.4", optional = true }
+
+[dev-dependencies]
+tokio = { version = "1.18.1", features = ["net", "io-util", "rt", "macros"] }
+
+[[example]]
+name = "tls_sender"
+required-features = ["tls", "clap"]
+
+[[example]]
+name = "tls_sender_async"
+required-features = ["tls", "clap", "async_tokio", "async_tls"]

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,21 @@
+use std::{env, process};
+
+fn main() {
+    if env::var_os("CARGO_FEATURE_ASYNC_TOKIO").is_some() {
+        match (env::var_os("CARGO_FEATURE_TLS_OPENSSL"), env::var_os("CARGO_FEATURE_TLS_OPENSSL_TOKIO")) {
+            (Some(_), None) => { fatal("to enable the features `tls_openssl` and `async_tokio` together, you must also enable the `tls_openssl_tokio` feature") },
+            (None, Some(_)) => { fatal("feature `tls_openssl_tokio` enabled without `tls_openssl`") },
+            _ => {},
+        }
+        match (env::var_os("CARGO_FEATURE_TLS_RUSTLS"), env::var_os("CARGO_FEATURE_TLS_RUSTLS_TOKIO")) {
+            (Some(_), None) => { fatal("to enable the features `tls_rustls` and `async_tokio` together, you must also enable the `tls_rustls_tokio` feature") },
+            (None, Some(_)) => { fatal("feature `tls_rustls_tokio` enabled without `tls_rustls`") },
+            _ => {},
+        }
+    }
+}
+
+fn fatal(msg: &str) {
+    eprintln!("error: {}", msg);
+    process::exit(1);
+}

--- a/examples/tls_sender.rs
+++ b/examples/tls_sender.rs
@@ -5,7 +5,7 @@ use std::convert::TryInto;
 use clap::Parser;
 
 use zbx_sender::{
-    tls::{ZabbixTlsCli, ZabbixTlsConfig},
+    tls::{ClapArgs, TlsConfig},
     Response, Result, Sender,
 };
 
@@ -16,7 +16,7 @@ struct Cli {
     #[clap(short, long, default_value = "10051")]
     port: u16,
     #[clap(flatten)]
-    tls: ZabbixTlsCli,
+    tls: ClapArgs,
 }
 
 fn send_one_value(sender: &Sender) -> Result<Response> {
@@ -25,7 +25,7 @@ fn send_one_value(sender: &Sender) -> Result<Response> {
 
 fn main() {
     let args = Cli::parse();
-    let tls_config: ZabbixTlsConfig = args.tls.try_into().unwrap();
+    let tls_config: TlsConfig = args.tls.try_into().unwrap();
     let sender = Sender::new(args.server.to_owned(), args.port)
         .with_tls(tls_config)
         .unwrap();

--- a/examples/tls_sender.rs
+++ b/examples/tls_sender.rs
@@ -1,0 +1,37 @@
+extern crate zbx_sender;
+
+use std::convert::TryInto;
+
+use clap::Parser;
+
+use zbx_sender::{
+    tls::{ZabbixTlsCli, ZabbixTlsConfig},
+    Response, Result, Sender,
+};
+
+#[derive(Parser)]
+struct Cli {
+    #[clap(short, long)]
+    server: String,
+    #[clap(short, long, default_value = "10051")]
+    port: u16,
+    #[clap(flatten)]
+    tls: ZabbixTlsCli,
+}
+
+fn send_one_value(sender: &Sender) -> Result<Response> {
+    sender.send(("host1", "key1", "value"))
+}
+
+fn main() {
+    let args = Cli::parse();
+    let tls_config: ZabbixTlsConfig = args.tls.try_into().unwrap();
+    let sender = Sender::new(args.server.to_owned(), args.port)
+        .with_tls(tls_config)
+        .unwrap();
+
+    match send_one_value(&sender) {
+        Ok(response) => println!("{:?} is success {} ", response, response.success()),
+        Err(e) => println!("Error {}", e),
+    }
+}

--- a/examples/tls_sender_async.rs
+++ b/examples/tls_sender_async.rs
@@ -5,7 +5,7 @@ use std::convert::TryInto;
 use clap::Parser;
 
 use zbx_sender::{
-    tls::{ZabbixTlsCli, ZabbixTlsConfig},
+    tls::{ClapArgs, TlsConfig},
     Response, Result, Sender,
 };
 
@@ -16,7 +16,7 @@ struct Cli {
     #[clap(short, long, default_value = "10051")]
     port: u16,
     #[clap(flatten)]
-    tls: ZabbixTlsCli,
+    tls: ClapArgs,
 }
 
 async fn send_one_value(sender: &Sender) -> Result<Response> {
@@ -26,7 +26,7 @@ async fn send_one_value(sender: &Sender) -> Result<Response> {
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
     let args = Cli::parse();
-    let tls_config: ZabbixTlsConfig = args.tls.try_into().unwrap();
+    let tls_config: TlsConfig = args.tls.try_into().unwrap();
     let sender = Sender::new(args.server.to_owned(), args.port)
         .with_tls(tls_config)
         .unwrap();

--- a/examples/tls_sender_async.rs
+++ b/examples/tls_sender_async.rs
@@ -1,0 +1,38 @@
+extern crate zbx_sender;
+
+use std::convert::TryInto;
+
+use clap::Parser;
+
+use zbx_sender::{
+    tls::{ZabbixTlsCli, ZabbixTlsConfig},
+    Response, Result, Sender,
+};
+
+#[derive(Parser)]
+struct Cli {
+    #[clap(short, long)]
+    server: String,
+    #[clap(short, long, default_value = "10051")]
+    port: u16,
+    #[clap(flatten)]
+    tls: ZabbixTlsCli,
+}
+
+async fn send_one_value(sender: &Sender) -> Result<Response> {
+    sender.send_async(("host1", "key1", "value")).await
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    let args = Cli::parse();
+    let tls_config: ZabbixTlsConfig = args.tls.try_into().unwrap();
+    let sender = Sender::new(args.server.to_owned(), args.port)
+        .with_tls(tls_config)
+        .unwrap();
+
+    match send_one_value(&sender).await {
+        Ok(response) => println!("{:?} is success {} ", response, response.success()),
+        Err(e) => println!("Error {}", e),
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,18 +2,33 @@
 
 use std::{io, result};
 
+/// A [std::result::Result] for the [zbx_sender::Error](Error) type
 pub type Result<T> = result::Result<T, Error>;
 
 // General error the crate
 #[derive(thiserror::Error, Debug)]
+/// Errors that occur during configuration of the Zabbix connection or submission of item values to
+/// Zabbix
 pub enum Error {
     #[error("invalid header protocol")]
+    /// The header received from Zabbix Server or Zabbix Proxy was invalid, most likely due to a
+    /// non-backwards-compatible change made in future versions of Zabbix.
     InvalidHeader,
+
     #[error(transparent)]
+    /// A system-level IO error, which can occur:
+    ///
+    /// * During configuration, when reading certificates or keys from the filesystem for TLS
+    ///   encryption.
+    /// * During sending of values, when there is a network error.
     IoError(#[from] io::Error),
+
     #[error(transparent)]
+    /// An error decoding JSON received from Zabbix Server or Zabbix Proxy.
     JsonError(#[from] serde_json::error::Error),
+
     #[cfg(feature = "_tls_common")]
     #[error(transparent)]
+    /// An error when configuring or establishing the TLS connection to Zabbix.
     TlsError(#[from] crate::tls::TlsError),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,8 +13,7 @@ pub enum Error {
     IoError(#[from] io::Error),
     #[error(transparent)]
     JsonError(#[from] serde_json::error::Error),
-    #[error("TLS settings not valid: {0}")]
-    TlsConfigError(String),
-    #[error("tried to encrypt with an \"unencrypted\" TLS config")]
-    TlsUnencrypted,
+    #[cfg(feature = "_tls_common")]
+    #[error(transparent)]
+    TlsError(#[from] crate::tls::TlsError),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,4 +13,8 @@ pub enum Error {
     IoError(#[from] io::Error),
     #[error(transparent)]
     JsonError(#[from] serde_json::error::Error),
+    #[error("TLS settings not valid: {0}")]
+    TlsConfigError(String),
+    #[error("tried to encrypt with an \"unencrypted\" TLS config")]
+    TlsUnencrypted,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,9 +23,12 @@
 //! - `clap` - Include the struct that implements `clap::Args`, which can be included in downstream
 //!   users of this library to get command line argument parsing that mirrors Zabbix native TLS
 //!   configuration.
-#![cfg_attr(all(feature = "_tls_common", feature = "clap"), doc = r##"
+#![cfg_attr(
+    all(feature = "_tls_common", feature = "clap"),
+    doc = r##"
       See details in the documentation for [tls::ClapArgs].
-"##)]
+"##
+)]
 
 use serde::{Deserialize, Serialize};
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,9 +105,9 @@ impl Sender {
     ///
     /// ## Examples
     /// ```no_run
-    /// use zbx_sender::{Sender, tls::Config};
+    /// use zbx_sender::{Sender, tls::TlsConfig};
     ///
-    /// let tls_config = Config::new_cert(
+    /// let tls_config = TlsConfig::new_cert(
     ///     "/etc/zabbix/sender.crt",
     ///     "/etc/zabbix/sender.key",
     /// );
@@ -142,7 +142,6 @@ impl Sender {
     /// ```no_run
     /// # use zbx_sender::{Error, Sender};
     /// # let zabbix = Sender::new("zabbix.example.com", 10051);
-    ///
     /// zabbix.send(("hostname", "item_key", "value"))?;
     /// # Ok::<(), Error>(())
     /// ```
@@ -211,9 +210,22 @@ impl Sender {
     }
 
     #[cfg(feature = "async_tokio")]
-    /// Async version of [self.send()]
+    /// Async version of `Sender.send()`
     ///
-    /// TODO
+    /// ## Arguments
+    ///
+    /// * `msg` - Any value for which the trait [ToMessage] is implemented
+    ///
+    /// ## Examples
+    /// ```no_run
+    /// # use zbx_sender::{Error, Sender};
+    /// # let zabbix = Sender::new("zabbix.example.com", 10051);
+    /// # tokio_test::block_on(async {
+    /// zabbix.send_async(("hostname", "item_key", "value")).await?;
+    /// # Ok::<(), Error>(())
+    /// # });
+    /// # Ok::<(), Error>(())
+    /// ```
     pub async fn send_async<T>(&self, msg: T) -> Result<Response>
     where
         T: ToMessage,

--- a/src/tls/cli.rs
+++ b/src/tls/cli.rs
@@ -95,7 +95,7 @@ impl TryFrom<ClapArgs> for super::TlsConfig {
         // Apply validation logic of builder to generate argument
         // conflicts (e.g. cert arguments when tls_connect=psk)
         builder
-            .build()
+            .fallible_build()
             .map_err(|e| Self::Error::raw(clap::ErrorKind::ArgumentConflict, e))
     }
 }

--- a/src/tls/cli.rs
+++ b/src/tls/cli.rs
@@ -38,11 +38,6 @@ pub struct ClapArgs {
     #[clap(long)]
     pub tls_ca_file: Option<PathBuf>,
 
-    /// Full pathname of a file containing revoked certificates
-    /// (default is to use system CRL)
-    #[clap(long)]
-    pub tls_crl_file: Option<PathBuf>,
-
     /// Allowed server certificate issuer
     #[clap(long)]
     pub tls_server_cert_issuer: Option<String>,
@@ -91,7 +86,6 @@ impl TryFrom<ClapArgs> for super::TlsConfig {
             psk_identity: Some(args.tls_psk_identity),
             psk_file: Some(args.tls_psk_file),
             ca_file: Some(args.tls_ca_file),
-            crl_file: Some(args.tls_crl_file),
             server_cert_issuer: Some(args.tls_server_cert_issuer),
             server_cert_subject: Some(args.tls_server_cert_subject),
             cert_file: Some(args.tls_cert_file),

--- a/src/tls/cli.rs
+++ b/src/tls/cli.rs
@@ -1,0 +1,73 @@
+use std::{convert::TryFrom, path::PathBuf};
+
+use super::ZabbixTlsConnect;
+
+#[derive(clap::Args)]
+pub struct ZabbixTlsCli {
+    /// How to connect to server or proxy
+    #[clap(long, arg_enum, default_value_t)]
+    pub tls_connect: ZabbixTlsConnect,
+
+    /// PSK-identity string
+    #[clap(long, required_if_eq("tls-connect", "psk"), conflicts_with_all(&["tls-cert-file","tls-key-file"]))]
+    pub tls_psk_identity: Option<String>,
+
+    /// Full pathname of a file containing the pre-shared key
+    #[clap(long, required_if_eq("tls-connect", "psk"), conflicts_with_all(&["tls-cert-file","tls-key-file"]))]
+    pub tls_psk_file: Option<PathBuf>,
+
+    /// Full pathname of a file containing the top-level CA(s) certificates for peer certificate verification
+    /// (default is to use system CA trust store)
+    #[clap(long)]
+    pub tls_ca_file: Option<PathBuf>,
+
+    /// Full pathname of a file containing revoked certificates
+    /// (default is to use system CRL)
+    #[clap(long)]
+    pub tls_crl_file: Option<PathBuf>,
+
+    /// Allowed server certificate issuer
+    #[clap(long)]
+    pub tls_server_cert_issuer: Option<String>,
+
+    /// Allowed server certificate subject
+    #[clap(long)]
+    pub tls_server_cert_subject: Option<String>,
+
+    /// Full pathname of a file containing the certificate or certificate chain
+    #[clap(long, required_if_eq("tls-connect", "cert"))]
+    pub tls_cert_file: Option<PathBuf>,
+
+    /// Full pathname of a file containing the private key
+    #[clap(long, required_if_eq("tls-connect", "cert"))]
+    pub tls_key_file: Option<PathBuf>,
+}
+
+impl TryFrom<ZabbixTlsCli> for super::ZabbixTlsConfig {
+    // Returns a clap::Error so that conversion errors
+    // can be handled and displayed during clap argument
+    // validation, if desired. clap::Error implements
+    // std::error::Error as well, so can also be used in
+    // other error contexts.
+    type Error = clap::Error;
+
+    fn try_from(args: ZabbixTlsCli) -> Result<Self, Self::Error> {
+        let builder = super::ZabbixTlsConfigBuilder {
+            connect: Some(args.tls_connect),
+            psk_identity: Some(args.tls_psk_identity),
+            psk_file: Some(args.tls_psk_file),
+            ca_file: Some(args.tls_ca_file),
+            crl_file: Some(args.tls_crl_file),
+            server_cert_issuer: Some(args.tls_server_cert_issuer),
+            server_cert_subject: Some(args.tls_server_cert_subject),
+            cert_file: Some(args.tls_cert_file),
+            key_file: Some(args.tls_key_file),
+        };
+
+        // Apply validation logic of builder to generate argument
+        // conflicts (e.g. cert arguments when tls_connect=psk)
+        builder
+            .build()
+            .map_err(|e| Self::Error::raw(clap::ErrorKind::ArgumentConflict, e))
+    }
+}

--- a/src/tls/mod.rs
+++ b/src/tls/mod.rs
@@ -14,17 +14,6 @@ use std::path::PathBuf;
 
 use derive_builder::Builder;
 
-macro_rules! unsupported_options {
-    ($obj:expr, $opt:ident)=>{
-        if $obj.$opt.is_some() {
-            return Err(Self::Error::Unsupported(stringify!($opt).into()));
-        }
-    };
-    ($obj:expr, $($opt:ident),+)=>{
-        $(unsupported_options!($obj, $opt));+
-    }
-}
-
 #[cfg(feature = "clap")]
 mod cli;
 #[cfg(feature = "clap")]
@@ -81,11 +70,6 @@ pub struct TlsConfig {
     #[builder(default, setter(strip_option, into))]
     ca_file: Option<PathBuf>,
 
-    /// (**Currently unsupported by both the `openssl` and `rustls` backends**) A file containing
-    /// revoked server certificates to reject connections from
-    #[builder(default, setter(strip_option, into))]
-    crl_file: Option<PathBuf>,
-
     /// An X.509 name that the server certificate's Issuer field must match exactly
     #[builder(default, setter(strip_option, into))]
     server_cert_issuer: Option<String>,
@@ -118,7 +102,6 @@ impl TlsConfigBuilder {
                     self,
                     "connection is unencrypted",
                     ca_file,
-                    crl_file,
                     server_cert_issuer,
                     server_cert_subject,
                     cert_file,
@@ -132,7 +115,6 @@ impl TlsConfigBuilder {
                     self,
                     "connection is encrypted by PSK",
                     ca_file,
-                    crl_file,
                     server_cert_issuer,
                     server_cert_subject,
                     cert_file,

--- a/src/tls/mod.rs
+++ b/src/tls/mod.rs
@@ -1,0 +1,364 @@
+use std::{
+    convert::TryFrom,
+    fs::File,
+    io::BufReader,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+use derive_builder::Builder;
+
+#[cfg(feature = "clap")]
+mod cli;
+#[cfg(feature = "clap")]
+pub use cli::ZabbixTlsCli;
+#[cfg(feature = "tracing")]
+use tracing::warn;
+use x509_certificate::CapturedX509Certificate;
+
+use crate::Error::TlsConfigError;
+
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "clap", derive(clap::ArgEnum))]
+pub enum ZabbixTlsConnect {
+    /// connect without encryption (default)
+    Unencrypted,
+    /// connect using TLS and a pre-shared key
+    Psk,
+    /// connect using TLS and a certificate
+    Cert,
+}
+
+impl Default for ZabbixTlsConnect {
+    fn default() -> Self {
+        Self::Unencrypted
+    }
+}
+
+#[derive(Builder, Default)]
+#[builder(
+    custom_constructor,
+    create_empty = "empty",
+    build_fn(validate = "Self::validate")
+)]
+pub struct ZabbixTlsConfig {
+    #[builder(setter(custom))]
+    pub(crate) connect: ZabbixTlsConnect,
+    #[builder(setter(custom))]
+    psk_identity: Option<String>,
+    #[builder(setter(custom))]
+    psk_file: Option<PathBuf>,
+    #[builder(default, setter(strip_option, into))]
+    ca_file: Option<PathBuf>,
+    #[builder(default, setter(strip_option, into))]
+    crl_file: Option<PathBuf>,
+    #[builder(default, setter(strip_option, into))]
+    server_cert_issuer: Option<String>,
+    #[builder(default, setter(strip_option, into))]
+    server_cert_subject: Option<String>,
+    #[builder(setter(custom))]
+    cert_file: Option<PathBuf>,
+    #[builder(setter(custom))]
+    key_file: Option<PathBuf>,
+}
+
+impl ZabbixTlsConfigBuilder {
+    fn validate(&self) -> Result<(), String> {
+        macro_rules! validate_inner_is_none{
+            ($obj:expr, $why:expr, $field:ident)=>{
+                if $obj.$field.as_ref()
+                    .map(|inner| inner.as_ref())
+                    .flatten()
+                    .is_some()
+                {
+                    return Err(format!("{} specified, but {}", stringify!($field), $why))
+                }
+            };
+            ($obj:expr, $why:expr, $($field:ident),+)=>{
+                $(validate_inner_is_none!($obj, $why, $field));+
+            }
+        }
+
+        match self.connect {
+            Some(ZabbixTlsConnect::Unencrypted) => {
+                validate_inner_is_none!(
+                    self,
+                    "connection is unencrypted",
+                    ca_file,
+                    crl_file,
+                    server_cert_issuer,
+                    server_cert_subject,
+                    cert_file,
+                    key_file,
+                    psk_identity,
+                    psk_file
+                );
+            }
+            Some(ZabbixTlsConnect::Psk) => {
+                validate_inner_is_none!(
+                    self,
+                    "connection is encrypted by PSK",
+                    ca_file,
+                    crl_file,
+                    server_cert_issuer,
+                    server_cert_subject,
+                    cert_file,
+                    key_file
+                );
+            }
+            Some(ZabbixTlsConnect::Cert) => {
+                validate_inner_is_none!(
+                    self,
+                    "connection is encrypted by certificate",
+                    psk_identity,
+                    psk_file
+                );
+            }
+            None => return Err("connection encryption type not specified".into()),
+        };
+        Ok(())
+    }
+}
+
+impl ZabbixTlsConfig {
+    pub fn new_unencrypted() -> Self {
+        Self::default()
+    }
+
+    pub fn new_psk(identity: impl Into<String>, key_file: impl Into<PathBuf>) -> Self {
+        // Run this configuration through the builder
+        // so that ...Builder::validate() gets run, in case
+        // any future changes add value validation.
+        ZabbixTlsConfigBuilder {
+            connect: Some(ZabbixTlsConnect::Psk),
+            psk_identity: Some(Some(identity.into())),
+            psk_file: Some(Some(key_file.into())),
+            cert_file: Some(None),
+            key_file: Some(None),
+            ..ZabbixTlsConfigBuilder::empty()
+        }
+        .build()
+        .expect("Programmer mistake in fields provided for ZabbixTlsConfigBuilder in ZabbixTlsConfig::new_psk()")
+    }
+
+    pub fn new_cert(cert_file: impl Into<PathBuf>, key_file: impl Into<PathBuf>) -> Self {
+        Self::cert_builder(cert_file, key_file).build().expect(
+            "Programmer mistake in fields provided for ZabbixTlsConfigBuilder in ZabbixTlsConfig::new_cert()",
+        )
+    }
+
+    pub fn cert_builder(
+        cert_file: impl Into<PathBuf>,
+        key_file: impl Into<PathBuf>,
+    ) -> ZabbixTlsConfigBuilder {
+        ZabbixTlsConfigBuilder {
+            connect: Some(ZabbixTlsConnect::Cert),
+            cert_file: Some(Some(cert_file.into())),
+            key_file: Some(Some(key_file.into())),
+            psk_identity: Some(None),
+            psk_file: Some(None),
+            ..ZabbixTlsConfigBuilder::empty()
+        }
+    }
+}
+
+impl TryFrom<ZabbixTlsConfig> for rustls::ClientConfig {
+    type Error = crate::Error;
+
+    fn try_from(zabbix_config: ZabbixTlsConfig) -> Result<Self, Self::Error> {
+        match zabbix_config.connect {
+            ZabbixTlsConnect::Unencrypted => Err(Self::Error::TlsUnencrypted),
+            ZabbixTlsConnect::Psk => todo!(),
+            ZabbixTlsConnect::Cert => {
+                let root_store = match zabbix_config.ca_file {
+                    None => load_system_roots()?,
+                    Some(path) => load_ca_file(path)?,
+                };
+                let verifier = ZabbixServerCertVerifier::new(
+                    root_store,
+                    zabbix_config.server_cert_subject,
+                    zabbix_config.server_cert_issuer,
+                );
+                let client_key =
+                    load_key_file(zabbix_config.key_file.expect("guaranteed by builder"))?;
+                let client_cert =
+                    load_cert_file(zabbix_config.cert_file.expect("guaranteed by builder"))?;
+                // `with_safe_defaults()` includes a set of cipher suites
+                // that partially overlaps with Zabbix's default cipher suites
+                rustls::ClientConfig::builder()
+                    .with_safe_defaults()
+                    .with_custom_certificate_verifier(Arc::new(verifier))
+                    .with_single_cert(client_cert, client_key)
+                    .map_err(|e| {
+                        TlsConfigError(format!("error loading client certificate or key: {}", e))
+                    })
+            }
+        }
+    }
+}
+
+struct ZabbixServerCertVerifier {
+    inner: rustls::client::WebPkiVerifier,
+    subject: Option<String>,
+    issuer: Option<String>,
+}
+
+impl ZabbixServerCertVerifier {
+    fn new(
+        root_store: rustls::RootCertStore,
+        subject: Option<String>,
+        issuer: Option<String>,
+    ) -> Self {
+        let verifier = rustls::client::WebPkiVerifier::new(root_store, None);
+        Self {
+            inner: verifier,
+            issuer,
+            subject,
+        }
+    }
+}
+
+impl rustls::client::ServerCertVerifier for ZabbixServerCertVerifier {
+    fn verify_server_cert(
+        &self,
+        end_entity: &rustls::Certificate,
+        intermediates: &[rustls::Certificate],
+        server_name: &rustls::ServerName,
+        scts: &mut dyn Iterator<Item = &[u8]>,
+        ocsp_response: &[u8],
+        now: std::time::SystemTime,
+    ) -> Result<rustls::client::ServerCertVerified, rustls::Error> {
+        use rustls::Error;
+
+        let parsed_cert = if self.subject.is_some() || self.issuer.is_some() {
+            let parsed_cert = CapturedX509Certificate::from_der(end_entity.0.as_slice())
+                .map_err(|e| Error::General(e.to_string()))?;
+            Some(parsed_cert)
+        } else {
+            None
+        };
+
+        self.inner
+            .verify_server_cert(
+                end_entity,
+                intermediates,
+                server_name,
+                scts,
+                ocsp_response,
+                now,
+            )
+            .and_then(|ok| {
+                if let Some(subject) = &self.subject {
+                    let subject_dn = parsed_cert
+                        .as_ref()
+                        .expect("guaranteed by above if conditions")
+                        .subject_name()
+                        .user_friendly_str()
+                        .map_err(|e| Error::InvalidCertificateData(e.to_string()))?;
+                    if &subject_dn != subject {
+                        return Err(Error::InvalidCertificateData(format!(
+                            "Certificate subject `{}` does not match required \
+                                 server_cert_subject from configuration: `{}`",
+                            subject_dn, subject
+                        )));
+                    }
+                }
+                Ok(ok)
+            })
+            .and_then(|ok| {
+                if let Some(issuer) = &self.issuer {
+                    let issuer_dn = parsed_cert
+                        .as_ref()
+                        .expect("guaranteed by above if conditions")
+                        .issuer_name()
+                        .user_friendly_str()
+                        .map_err(|e| Error::InvalidCertificateData(e.to_string()))?;
+                    if &issuer_dn != issuer {
+                        return Err(Error::InvalidCertificateData(format!(
+                            "Certificate issuer `{}` does not match required \
+                                 server_cert_issuer from configuration: `{}`",
+                            issuer_dn, issuer
+                        )));
+                    }
+                }
+                Ok(ok)
+            })
+    }
+}
+
+fn load_cert_file(path: impl AsRef<Path>) -> Result<Vec<rustls::Certificate>, crate::Error> {
+    let path = path.as_ref();
+    let mut rdr = BufReader::new(File::open(&path)?);
+    let chain: Vec<rustls::Certificate> = rustls_pemfile::certs(&mut rdr)?
+        .into_iter()
+        .map(rustls::Certificate)
+        .collect();
+    if chain.is_empty() {
+        Err(TlsConfigError(format!(
+            "no certificates found in {}",
+            path.to_string_lossy()
+        )))
+    } else {
+        Ok(chain)
+    }
+}
+
+fn load_key_file(path: impl AsRef<Path>) -> Result<rustls::PrivateKey, crate::Error> {
+    use rustls_pemfile::Item::*;
+
+    let path = path.as_ref();
+    let mut rdr = BufReader::new(File::open(&path)?);
+    let mut found_key = None;
+    while let Some(item) = rustls_pemfile::read_one(&mut rdr)? {
+        match item {
+            RSAKey(v) | PKCS8Key(v) | ECKey(v) => {
+                if found_key.is_some() {
+                    return Err(TlsConfigError(format!(
+                        "multiple keys found in {}",
+                        path.to_string_lossy()
+                    )));
+                }
+                found_key = Some(rustls::PrivateKey(v));
+            }
+            _ => {
+                #[cfg(feature = "tracing")]
+                warn!("certificate found in {}", path.to_string_lossy())
+            }
+        }
+    }
+    found_key.ok_or_else(|| TlsConfigError(format!("no keys found in {}", path.to_string_lossy())))
+}
+
+fn load_ca_file(path: impl AsRef<Path>) -> Result<rustls::RootCertStore, crate::Error> {
+    let mut roots = rustls::RootCertStore::empty();
+    let mut rdr = BufReader::new(File::open(path.as_ref())?);
+    while let Some(item) = rustls_pemfile::read_one(&mut rdr)? {
+        if let rustls_pemfile::Item::X509Certificate(cert) = item {
+            let cert = rustls::Certificate(cert);
+            roots
+                .add(&cert)
+                .map_err(|e| TlsConfigError(format!("error loading ca_file: {}", e)))?;
+        } else {
+            #[cfg(feature = "tracing")]
+            warn!(
+                "found non-certificate item in {}",
+                path.as_ref().to_string_lossy()
+            );
+        }
+    }
+    Ok(roots)
+}
+
+fn load_system_roots() -> Result<rustls::RootCertStore, crate::Error> {
+    let mut roots = rustls::RootCertStore::empty();
+    for cert in rustls_native_certs::load_native_certs()? {
+        let cert = rustls::Certificate(cert.0);
+        roots.add(&cert).map_err(|e| {
+            TlsConfigError(format!(
+                "error loading certificate from system roots: {}",
+                e
+            ))
+        })?;
+    }
+    Ok(roots)
+}

--- a/src/tls/mod.rs
+++ b/src/tls/mod.rs
@@ -45,7 +45,7 @@ pub enum EncryptionType {
 #[builder(
     custom_constructor,
     create_empty = "empty",
-    build_fn(validate = "Self::validate"),
+    build_fn(private, name = "fallible_build", validate = "Self::validate"),
     pattern = "owned"
 )]
 /// TLS configuration for [Sender](crate::Sender)
@@ -133,6 +133,12 @@ impl TlsConfigBuilder {
         };
         Ok(())
     }
+
+    /// Build a new [`TlsConfig`]
+    pub fn build(self) -> TlsConfig {
+        self.fallible_build()
+            .expect("programmer error: should be guaranteed by builder")
+    }
 }
 
 impl TlsConfig {
@@ -155,7 +161,7 @@ impl TlsConfig {
             key_file: Some(None),
             ..TlsConfigBuilder::empty()
         }
-        .build()
+        .fallible_build()
         .expect("Programmer mistake in fields provided for TlsConfigBuilder in Config::new_psk()")
     }
 
@@ -166,7 +172,7 @@ impl TlsConfig {
     /// * `cert_file` - the full path to a certificate (or certificate chain) in PEM format
     /// * `key_file` - the full path to the certificate's private key in PEM format
     pub fn new_cert(cert_file: impl Into<PathBuf>, key_file: impl Into<PathBuf>) -> Self {
-        Self::cert_builder(cert_file, key_file).build().expect(
+        Self::cert_builder(cert_file, key_file).fallible_build().expect(
             "Programmer mistake in fields provided for TlsConfigBuilder in Config::new_cert()",
         )
     }

--- a/src/tls/mod.rs
+++ b/src/tls/mod.rs
@@ -172,9 +172,11 @@ impl TlsConfig {
     /// * `cert_file` - the full path to a certificate (or certificate chain) in PEM format
     /// * `key_file` - the full path to the certificate's private key in PEM format
     pub fn new_cert(cert_file: impl Into<PathBuf>, key_file: impl Into<PathBuf>) -> Self {
-        Self::cert_builder(cert_file, key_file).fallible_build().expect(
-            "Programmer mistake in fields provided for TlsConfigBuilder in Config::new_cert()",
-        )
+        Self::cert_builder(cert_file, key_file)
+            .fallible_build()
+            .expect(
+                "Programmer mistake in fields provided for TlsConfigBuilder in Config::new_cert()",
+            )
     }
 
     /// Create an instance of [TlsConfigBuilder] to configure certificate encryption with server

--- a/src/tls/openssl.rs
+++ b/src/tls/openssl.rs
@@ -99,7 +99,6 @@ impl TryFrom<TlsConfig> for SslConnector {
     fn try_from(zabbix_config: TlsConfig) -> Result<Self, Self::Error> {
         use EncryptionType::*;
 
-        unsupported_options!(zabbix_config, crl_file);
         if let EncryptionType::Unencrypted = zabbix_config.connect {
             return Err(Self::Error::Unencrypted);
         }

--- a/src/tls/openssl.rs
+++ b/src/tls/openssl.rs
@@ -1,0 +1,313 @@
+use std::{
+    convert::{TryFrom, TryInto},
+    fs::File,
+    io::{Read, Write},
+    path::Path,
+};
+
+use openssl::{
+    ec::EcKey,
+    error::ErrorStack,
+    nid::Nid,
+    ssl::{
+        HandshakeError, SslConnector, SslConnectorBuilder, SslFiletype, SslMethod, SslOptions,
+        SslSessionCacheMode, SslStream, SslVerifyMode,
+    },
+    x509::{X509NameEntries, X509StoreContextRef},
+};
+use openssl_errors::{openssl_errors, put_error};
+use thiserror::Error;
+#[cfg(feature = "async_tokio")]
+use tokio_openssl::SslStream as AsyncSslStream;
+#[cfg(feature = "tracing")]
+use tracing::error;
+
+use super::{ZabbixTlsConfig, ZabbixTlsConnect};
+
+#[derive(Error, Debug)]
+pub enum TlsError {
+    #[error("Configuration error: {0}")]
+    Config(String),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error(transparent)]
+    Stack(#[from] ErrorStack),
+    #[error(transparent)]
+    Handshake(#[from] HandshakeError<std::net::TcpStream>),
+    #[error(transparent)]
+    AsyncHandshake(#[from] openssl::ssl::Error),
+    #[error("tried to encrypt with an \"unencrypted\" TLS config")]
+    Unencrypted,
+    #[error("option not supported: {0}")]
+    Unsupported(String),
+}
+
+pub struct StreamAdapter {
+    connector: SslConnector,
+}
+
+const CIPHERS_CERT_ECDHE: &str = "EECDH+aRSA+AES128:";
+const CIPHERS_CERT: &str = "RSA+aRSA+AES128";
+const CIPHERS_PSK_ECDHE: &str = "kECDHEPSK+AES128";
+const CIPHERS_PSK: &str = "kPSK+AES128";
+const CIPHERS_PSK_PRE110: &str = "PSK-AES128-CBC-SHA";
+const CIPHERS_PSK_TLS13: &str = "TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256";
+
+impl StreamAdapter {
+    pub fn connect(
+        &self,
+        server_name: impl AsRef<str>,
+        stream: std::net::TcpStream,
+    ) -> Result<SslStream<std::net::TcpStream>, TlsError> {
+        let stream = self.connector.connect(server_name.as_ref(), stream)?;
+        Ok(stream)
+    }
+
+    #[cfg(feature = "async_tokio")]
+    pub async fn connect_async(
+        &self,
+        server_name: impl AsRef<str>,
+        stream: tokio::net::TcpStream,
+    ) -> Result<AsyncSslStream<tokio::net::TcpStream>, TlsError> {
+        use std::pin::Pin;
+
+        let mut stream = self
+            .connector
+            .configure()
+            .and_then(|c| c.into_ssl(server_name.as_ref()))
+            .and_then(move |s| AsyncSslStream::new(s, stream))?;
+        let mut pinned_stream = Pin::new(&mut stream);
+        pinned_stream.as_mut().connect().await?;
+        Ok(stream)
+    }
+}
+
+impl TryFrom<ZabbixTlsConfig> for StreamAdapter {
+    type Error = crate::Error;
+
+    fn try_from(config: ZabbixTlsConfig) -> Result<Self, Self::Error> {
+        Ok(Self {
+            connector: config.try_into()?,
+        })
+    }
+}
+
+impl TryFrom<ZabbixTlsConfig> for SslConnector {
+    type Error = TlsError;
+
+    fn try_from(zabbix_config: ZabbixTlsConfig) -> Result<Self, Self::Error> {
+        use ZabbixTlsConnect::*;
+
+        unsupported_options!(zabbix_config, crl_file);
+        if let ZabbixTlsConnect::Unencrypted = zabbix_config.connect {
+            return Err(Self::Error::Unencrypted);
+        }
+        // Do some stuff common to PSK and certificate encryption
+        let mut builder = SslConnector::builder(SslMethod::tls())?;
+        builder.set_session_cache_mode(SslSessionCacheMode::OFF);
+        builder.set_options(SslOptions::CIPHER_SERVER_PREFERENCE);
+        builder.set_options(SslOptions::NO_TICKET);
+        set_openssl_ciphers(&mut builder, &zabbix_config.connect)?;
+
+        match &zabbix_config.connect {
+            Unencrypted => unreachable!("early return above"),
+            Psk => {
+                let psk_identity = zabbix_config.psk_identity.expect("guaranteed by builder");
+                let psk_key = load_psk_key(zabbix_config.psk_file.expect("guaranteed by builder"))?;
+
+                builder.set_psk_client_callback(
+                    move |_ssl, _hint, mut identity_buffer, mut psk_buffer| {
+                        use ZbxSenderOpenSSLError as E;
+                        identity_buffer
+                            .write_all(psk_identity.as_bytes())
+                            .map_err(|err| {
+                                put_error!(E::CONNECT_WRITE_ID, E::IO_ERROR, "{}", err);
+                                ErrorStack::get()
+                            })?;
+                        psk_buffer.write_all(&psk_key).map_err(|err| {
+                            put_error!(E::CONNECT_WRITE_KEY, E::IO_ERROR, "{}", err);
+                            ErrorStack::get()
+                        })?;
+                        Ok(psk_key.len())
+                    },
+                );
+
+                Ok(builder.build())
+            }
+            Cert => {
+                if let Some(path) = &zabbix_config.ca_file {
+                    builder.set_ca_file(path)?;
+                }
+                builder.set_private_key_file(
+                    zabbix_config
+                        .key_file
+                        .as_ref()
+                        .expect("guaranteed by builder"),
+                    SslFiletype::PEM,
+                )?;
+                builder.set_certificate_chain_file(
+                    zabbix_config
+                        .cert_file
+                        .as_ref()
+                        .expect("guaranteed by builder"),
+                )?;
+                if zabbix_config.server_cert_issuer.is_some()
+                    || zabbix_config.server_cert_subject.is_some()
+                {
+                    builder.set_verify_callback(
+                        SslVerifyMode::PEER,
+                        move |is_valid_cert: bool, ctx: &mut X509StoreContextRef| {
+                            let required_subject = zabbix_config.server_cert_subject.as_deref();
+                            let required_issuer = zabbix_config.server_cert_issuer.as_deref();
+                            verify_subject_issuer(
+                                required_subject,
+                                required_issuer,
+                                is_valid_cert,
+                                ctx,
+                            )
+                        },
+                    );
+                }
+                Ok(builder.build())
+            }
+        }
+    }
+}
+
+fn set_openssl_ciphers(
+    builder: &mut SslConnectorBuilder,
+    mode: &ZabbixTlsConnect,
+) -> Result<(), ErrorStack> {
+    use ZabbixTlsConnect::*;
+
+    let openssl_version_number = openssl::version::number();
+    if matches!(mode, Psk) && openssl_version_number >= 0x1010100f {
+        // OpenSSL >=1.1.1
+        builder.set_ciphersuites(CIPHERS_PSK_TLS13)?;
+    }
+    let ciphers = if openssl_version_number >= 0x1010000f {
+        // OpenSSL >=1.1.0
+        let ecdhe_res = set_ecdhe_params(builder);
+        match (mode, ecdhe_res) {
+            (Psk, Ok(_)) => format!("{}:{}", CIPHERS_PSK_ECDHE, CIPHERS_PSK),
+            (Cert, Ok(_)) => format!("{}:{}", CIPHERS_CERT_ECDHE, CIPHERS_CERT),
+            (Psk, Err(_)) => CIPHERS_PSK.into(),
+            (Cert, Err(_)) => CIPHERS_CERT.into(),
+            _ => unreachable!("never called for Unencrypted variant"),
+        }
+    } else {
+        match mode {
+            Psk => CIPHERS_PSK_PRE110.into(),
+            Cert => CIPHERS_CERT.into(),
+            _ => unreachable!("never called for Unencrypted variant"),
+        }
+    };
+    builder.set_cipher_list(&ciphers)
+}
+
+fn verify_subject_issuer(
+    required_subject: Option<&str>,
+    required_issuer: Option<&str>,
+    is_valid_cert: bool,
+    ctx: &mut X509StoreContextRef,
+) -> bool {
+    fn entries_to_string(entries: X509NameEntries) -> String {
+        use std::fmt::Write as _;
+        let mut out = String::default();
+        for part in entries {
+            let key = if let Ok(k) = part.object().nid().short_name() {
+                k
+            } else {
+                continue;
+            };
+            let value = if let Ok(v) = part.data().as_utf8() {
+                v
+            } else {
+                continue;
+            };
+            if !out.is_empty() {
+                write!(out, ", ").unwrap();
+            }
+            write!(out, "{}={}", key, value).unwrap();
+        }
+        out
+    }
+
+    if !is_valid_cert {
+        return false;
+    }
+    let cert = ctx.chain().and_then(|ch| ch.into_iter().next());
+    match cert {
+        None => {
+            #[cfg(feature = "tracing")]
+            error!("Certificate could not be found in server response");
+            return false;
+        }
+        Some(cert) => {
+            if let Some(subject) = required_subject {
+                let cert_subject = entries_to_string(cert.subject_name().entries());
+                if cert_subject != subject {
+                    #[cfg(feature = "tracing")]
+                    error!(
+                        "Certificate subject (\"{}\") does not match configured subject (\"{}\")",
+                        cert_subject, subject
+                    );
+                    return false;
+                }
+            }
+            if let Some(issuer) = required_issuer {
+                let cert_issuer = entries_to_string(cert.issuer_name().entries());
+                if cert_issuer != issuer {
+                    #[cfg(feature = "tracing")]
+                    error!(
+                        "Certificate issuer (\"{}\") does not match configured issuer (\"{}\")",
+                        cert_issuer, issuer
+                    );
+                    return false;
+                }
+            }
+        }
+    }
+
+    true
+}
+
+fn set_ecdhe_params(builder: &mut SslConnectorBuilder) -> Result<(), openssl::error::ErrorStack> {
+    let openssl_version_number = openssl::version::number();
+    let ec_curve = Nid::X9_62_PRIME256V1;
+    if openssl_version_number >= 0x3000000f {
+        builder.set_groups_list(ec_curve.short_name()?)?;
+    } else {
+        let ecdh = EcKey::from_curve_name(ec_curve)?;
+        builder.set_options(SslOptions::SINGLE_ECDH_USE);
+        builder.set_tmp_ecdh(&ecdh)?; // todo?: set this at connection time instead of at init?
+    }
+    Ok(())
+}
+
+fn load_psk_key(path: impl AsRef<Path>) -> Result<Vec<u8>, TlsError> {
+    let path = path.as_ref();
+
+    let mut buffer = Vec::new();
+    let mut rdr = File::open(&path)?;
+    rdr.read_to_end(&mut buffer)?;
+    buffer = buffer.into_iter().filter(u8::is_ascii_hexdigit).collect();
+
+    buffer = hex::decode(buffer)
+        .map_err(|_| TlsError::Config("unable to decode PSK key as hexidecimal digits".into()))?;
+
+    Ok(buffer)
+}
+
+openssl_errors! {
+    pub library ZbxSenderOpenSSLError("Zabbix Sender Library") {
+        functions {
+            CONNECT_WRITE_ID("set_psk_client_callback:identity_buffer.write_all");
+            CONNECT_WRITE_KEY("set_psk_client_callback:psk_buffer.write_all");
+        }
+
+        reasons {
+            IO_ERROR("An IO error occurred");
+        }
+    }
+}

--- a/src/tls/openssl.rs
+++ b/src/tls/openssl.rs
@@ -22,7 +22,7 @@ use tokio_openssl::SslStream as AsyncSslStream;
 #[cfg(feature = "tracing")]
 use tracing::error;
 
-use super::{TlsConfig, EncryptionType};
+use super::{EncryptionType, TlsConfig};
 
 #[derive(Error, Debug)]
 pub enum TlsError {

--- a/src/tls/rustls.rs
+++ b/src/tls/rustls.rs
@@ -12,7 +12,7 @@ use thiserror::Error;
 use tracing::warn;
 use x509_certificate::CapturedX509Certificate;
 
-use super::{TlsConfig, EncryptionType};
+use super::{EncryptionType, TlsConfig};
 
 macro_rules! unsupported_options {
     ($obj:expr, $opt:ident)=>{

--- a/src/tls/rustls.rs
+++ b/src/tls/rustls.rs
@@ -1,0 +1,274 @@
+use std::{
+    convert::{TryFrom, TryInto},
+    fs::File,
+    io::BufReader,
+    path::Path,
+    sync::Arc,
+};
+
+use rustls::{client::InvalidDnsNameError, ClientConnection, ServerName, StreamOwned};
+use thiserror::Error;
+#[cfg(feature = "tracing")]
+use tracing::warn;
+use x509_certificate::CapturedX509Certificate;
+
+use super::{ZabbixTlsConfig, ZabbixTlsConnect};
+
+#[derive(Error, Debug)]
+pub enum TlsError {
+    #[error(transparent)]
+    Rustls(#[from] rustls::Error),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error(transparent)]
+    InvalidServerName(#[from] InvalidDnsNameError),
+    #[error("Configuration error: {0}")]
+    Config(String),
+    #[error("tried to encrypt with an \"unencrypted\" TLS config")]
+    Unencrypted,
+    #[error("option not supported: {0}")]
+    Unsupported(String),
+}
+
+pub struct StreamAdapter {
+    config: Arc<rustls::ClientConfig>,
+}
+
+impl StreamAdapter {
+    pub fn connect(
+        &self,
+        server_name: impl AsRef<str>,
+        stream: std::net::TcpStream,
+    ) -> Result<StreamOwned<ClientConnection, std::net::TcpStream>, TlsError> {
+        let server_name = server_name.as_ref().try_into()?;
+        let conn = ClientConnection::new(Arc::clone(&self.config), server_name)?;
+        Ok(StreamOwned::new(conn, stream))
+    }
+
+    #[cfg(feature = "async_tokio")]
+    pub async fn connect_async(
+        &self,
+        server_name: impl AsRef<str>,
+        stream: tokio::net::TcpStream,
+    ) -> Result<tokio_rustls::client::TlsStream<tokio::net::TcpStream>, TlsError> {
+        let server_name = server_name.as_ref().try_into()?;
+        let conn = tokio_rustls::TlsConnector::from(Arc::clone(&self.config));
+        conn.connect(server_name, stream)
+            .await
+            .map_err(|e| e.into())
+    }
+}
+
+impl TryFrom<ZabbixTlsConfig> for StreamAdapter {
+    type Error = crate::Error;
+
+    fn try_from(config: ZabbixTlsConfig) -> Result<Self, Self::Error> {
+        let config = config.try_into()?;
+        Ok(Self {
+            config: Arc::new(config),
+        })
+    }
+}
+
+impl TryFrom<ZabbixTlsConfig> for rustls::ClientConfig {
+    type Error = TlsError;
+
+    fn try_from(zabbix_config: ZabbixTlsConfig) -> Result<Self, Self::Error> {
+        unsupported_options!(zabbix_config, crl_file, psk_identity, psk_file);
+        match zabbix_config.connect {
+            ZabbixTlsConnect::Unencrypted => Err(Self::Error::Unencrypted),
+            ZabbixTlsConnect::Psk => Err(Self::Error::Unsupported(
+                "rustls does not yet support PSK encryption".into(),
+            )),
+            ZabbixTlsConnect::Cert => {
+                let root_store = match zabbix_config.ca_file {
+                    None => load_system_roots()?,
+                    Some(path) => load_ca_file(path)?,
+                };
+                let verifier = ZabbixServerCertVerifier::new(
+                    root_store,
+                    zabbix_config.server_cert_subject,
+                    zabbix_config.server_cert_issuer,
+                );
+                let client_key =
+                    load_key_file(zabbix_config.key_file.expect("guaranteed by builder"))?;
+                let client_cert =
+                    load_cert_file(zabbix_config.cert_file.expect("guaranteed by builder"))?;
+                // `with_safe_defaults()` includes a set of cipher suites
+                // that partially overlaps with Zabbix's default cipher suites
+                rustls::ClientConfig::builder()
+                    .with_safe_defaults()
+                    .with_custom_certificate_verifier(Arc::new(verifier))
+                    .with_single_cert(client_cert, client_key)
+                    .map_err(|e| e.into())
+            }
+        }
+    }
+}
+
+struct ZabbixServerCertVerifier {
+    inner: rustls::client::WebPkiVerifier,
+    subject: Option<String>,
+    issuer: Option<String>,
+}
+
+impl ZabbixServerCertVerifier {
+    fn new(
+        root_store: rustls::RootCertStore,
+        subject: Option<String>,
+        issuer: Option<String>,
+    ) -> Self {
+        let verifier = rustls::client::WebPkiVerifier::new(root_store, None);
+        Self {
+            inner: verifier,
+            issuer,
+            subject,
+        }
+    }
+}
+
+impl rustls::client::ServerCertVerifier for ZabbixServerCertVerifier {
+    fn verify_server_cert(
+        &self,
+        end_entity: &rustls::Certificate,
+        intermediates: &[rustls::Certificate],
+        server_name: &ServerName,
+        scts: &mut dyn Iterator<Item = &[u8]>,
+        ocsp_response: &[u8],
+        now: std::time::SystemTime,
+    ) -> Result<rustls::client::ServerCertVerified, rustls::Error> {
+        use rustls::Error;
+
+        let parsed_cert = if self.subject.is_some() || self.issuer.is_some() {
+            let parsed_cert = CapturedX509Certificate::from_der(end_entity.0.as_slice())
+                .map_err(|e| Error::General(e.to_string()))?;
+            Some(parsed_cert)
+        } else {
+            None
+        };
+
+        self.inner
+            .verify_server_cert(
+                end_entity,
+                intermediates,
+                server_name,
+                scts,
+                ocsp_response,
+                now,
+            )
+            .and_then(|ok| {
+                if let Some(subject) = &self.subject {
+                    let subject_dn = parsed_cert
+                        .as_ref()
+                        .expect("guaranteed by above if conditions")
+                        .subject_name()
+                        .user_friendly_str()
+                        .map_err(|e| Error::InvalidCertificateData(e.to_string()))?;
+                    if &subject_dn != subject {
+                        return Err(Error::InvalidCertificateData(format!(
+                            "Certificate subject `{}` does not match required \
+                                 server_cert_subject from configuration: `{}`",
+                            subject_dn, subject
+                        )));
+                    }
+                }
+                Ok(ok)
+            })
+            .and_then(|ok| {
+                if let Some(issuer) = &self.issuer {
+                    let issuer_dn = parsed_cert
+                        .as_ref()
+                        .expect("guaranteed by above if conditions")
+                        .issuer_name()
+                        .user_friendly_str()
+                        .map_err(|e| Error::InvalidCertificateData(e.to_string()))?;
+                    if &issuer_dn != issuer {
+                        return Err(Error::InvalidCertificateData(format!(
+                            "Certificate issuer `{}` does not match required \
+                                 server_cert_issuer from configuration: `{}`",
+                            issuer_dn, issuer
+                        )));
+                    }
+                }
+                Ok(ok)
+            })
+    }
+}
+
+fn load_cert_file(path: impl AsRef<Path>) -> Result<Vec<rustls::Certificate>, TlsError> {
+    let path = path.as_ref();
+    let mut rdr = BufReader::new(File::open(&path)?);
+    let chain: Vec<rustls::Certificate> = rustls_pemfile::certs(&mut rdr)?
+        .into_iter()
+        .map(rustls::Certificate)
+        .collect();
+    if chain.is_empty() {
+        Err(TlsError::Config(format!(
+            "no certificates found in {}",
+            path.to_string_lossy()
+        )))
+    } else {
+        Ok(chain)
+    }
+}
+
+fn load_key_file(path: impl AsRef<Path>) -> Result<rustls::PrivateKey, TlsError> {
+    use rustls_pemfile::Item::*;
+
+    let path = path.as_ref();
+    let mut rdr = BufReader::new(File::open(&path)?);
+    let mut found_key = None;
+    while let Some(item) = rustls_pemfile::read_one(&mut rdr)? {
+        match item {
+            RSAKey(v) | PKCS8Key(v) | ECKey(v) => {
+                if found_key.is_some() {
+                    return Err(TlsError::Config(format!(
+                        "multiple keys found in {}",
+                        path.to_string_lossy()
+                    )));
+                }
+                found_key = Some(rustls::PrivateKey(v));
+            }
+            _ => {
+                #[cfg(feature = "tracing")]
+                warn!("certificate found in {}", path.to_string_lossy())
+            }
+        }
+    }
+    found_key
+        .ok_or_else(|| TlsError::Config(format!("no keys found in {}", path.to_string_lossy())))
+}
+
+fn load_ca_file(path: impl AsRef<Path>) -> Result<rustls::RootCertStore, TlsError> {
+    let mut roots = rustls::RootCertStore::empty();
+    let mut rdr = BufReader::new(File::open(path.as_ref())?);
+    while let Some(item) = rustls_pemfile::read_one(&mut rdr)? {
+        if let rustls_pemfile::Item::X509Certificate(cert) = item {
+            let cert = rustls::Certificate(cert);
+            roots
+                .add(&cert)
+                .map_err(|e| TlsError::Config(format!("error loading ca_file: {}", e)))?;
+        } else {
+            #[cfg(feature = "tracing")]
+            warn!(
+                "found non-certificate item in {}",
+                path.as_ref().to_string_lossy()
+            );
+        }
+    }
+    Ok(roots)
+}
+
+fn load_system_roots() -> Result<rustls::RootCertStore, TlsError> {
+    let mut roots = rustls::RootCertStore::empty();
+    for cert in rustls_native_certs::load_native_certs()? {
+        let cert = rustls::Certificate(cert.0);
+        roots.add(&cert).map_err(|e| {
+            TlsError::Config(format!(
+                "error loading certificate from system roots: {}",
+                e
+            ))
+        })?;
+    }
+    Ok(roots)
+}


### PR DESCRIPTION
* Adds TLS support with a choice of `openssl` or `rustls` (no PSK support for the latter)
* Optionally includes implementation of `clap::Args` that provides command line arguments identical to Zabbix native TLS options
* Adds optional logging via the `tracing` crate