### PR TITLE
"Pass through" `Send + Sync` traits for `AsyncStream`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,10 +47,10 @@ trait Stream: std::io::Read + std::io::Write {}
 impl<T: std::io::Read + std::io::Write> Stream for T {}
 
 #[cfg(feature = "async_tokio")]
-trait AsyncStream: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin {}
+trait AsyncStream: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + Sync {}
 
 #[cfg(feature = "async_tokio")]
-impl<T: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin> AsyncStream for T {}
+impl<T: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + Sync> AsyncStream for T {}
 
 pub use crate::error::{Error, Result};
 


### PR DESCRIPTION
zbx_sender uses an AsyncStream trait to represent an unified
AsyncRead + AsyncWrite object. Actually using this trait requires
Send + Sync in practice, but I forgot to specify them as super-traits
the first time around.

The problem showed itself when trying to utilize the new async
code in a warp-based HTTP server.