### PR TITLE
`serde::Deserialize` for `tls::cli::ClapArgs` plus additional bugfixes

### DIFF
--- a/.github/workflows/zabbix-integration.yml
+++ b/.github/workflows/zabbix-integration.yml
@@ -156,7 +156,7 @@ jobs:
           set -x
           ./script/zabbix_api_setup.py \
             --wait 120 \
-            --allow-ips '127.0.0.1, ::1, 172.16.0.0/12' \
+            --allow-ips '127.0.0.1,::1,172.16.0.0/12' \
             --tls-accept ${{ matrix.encryption }} \
             $PSK_ARGS \
             http://localhost:8080

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,10 +47,10 @@ trait Stream: std::io::Read + std::io::Write {}
 impl<T: std::io::Read + std::io::Write> Stream for T {}
 
 #[cfg(feature = "async_tokio")]
-trait AsyncStream: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin {}
+trait AsyncStream: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + Sync {}
 
 #[cfg(feature = "async_tokio")]
-impl<T: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin> AsyncStream for T {}
+impl<T: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + Sync> AsyncStream for T {}
 
 pub use crate::error::{Error, Result};
 

--- a/src/tls/cli.rs
+++ b/src/tls/cli.rs
@@ -6,6 +6,9 @@ use super::EncryptionType;
 /// Implementation of [`clap::Args`](https://docs.rs/clap/3/clap/trait.Args.html) that mirrors
 /// the [Zabbix native tool TLS configuration
 /// options](https://www.zabbix.com/documentation/current/en/manpages/zabbix_sender).
+///
+/// Also implements `serde::Deserialize` so that it can be used as a part of a larger `Deserialize`
+/// struct, like for a configuration file.
 pub struct ClapArgs {
     /// How to encrypt the connection to Zabbix Server or Proxy
     #[clap(long, arg_enum, default_value_t)]

--- a/src/tls/cli.rs
+++ b/src/tls/cli.rs
@@ -2,13 +2,13 @@ use std::{convert::TryFrom, path::PathBuf};
 
 use super::EncryptionType;
 
-#[derive(clap::Args)]
+#[derive(clap::Args, serde::Deserialize, Clone, Debug)]
 /// Implementation of [`clap::Args`](https://docs.rs/clap/3/clap/trait.Args.html) that mirrors
 /// the [Zabbix native tool TLS configuration
 /// options](https://www.zabbix.com/documentation/current/en/manpages/zabbix_sender).
 pub struct ClapArgs {
     /// How to encrypt the connection to Zabbix Server or Proxy
-    #[clap(long, arg_enum, default_value = "unencrypted")]
+    #[clap(long, arg_enum, default_value_t)]
     pub tls_connect: EncryptionType,
 
     /// PSK-identity string

--- a/src/tls/mod.rs
+++ b/src/tls/mod.rs
@@ -29,10 +29,11 @@ mod openssl;
 #[cfg(feature = "tls_openssl")]
 pub(crate) use self::openssl::{StreamAdapter, TlsError};
 
-#[derive(Clone, Debug)]
+#[derive(serde::Deserialize, Clone, Debug, Default)]
 #[cfg_attr(feature = "clap", derive(clap::ArgEnum))]
 /// Encryption method used for the connection to Zabbix
 pub enum EncryptionType {
+    #[default]
     /// connect without encryption (default)
     Unencrypted,
     /// connect using TLS and a pre-shared key


### PR DESCRIPTION
Adds `serde` support for `ClapArgs`, making it easier for downstream users to incorporate it into a larger app configuration struct that deserializes from a configuration file. `zbx_sender` already depends on `serde`, so this is a low-cost additional feature.

Also, two bug fixes:
* Add `Send + Sync` to the internal `AsyncStream` trait constraints, which allows it to be included in downstream async tasks.
* Remove spaces from the IP range specified in CI. Zabbix docs say that spaces are supported, but CI broke on validating the specified CIDR. A review of Zabbix's parsing code looks like there is no allowance for spaces.