### PR TITLE
Update CI dependencies; update integration tests for Zabbix 7.2

### DIFF
--- a/.github/actions/generate-password/action.yml
+++ b/.github/actions/generate-password/action.yml
@@ -16,5 +16,5 @@ runs:
   using: "composite"
   steps:
     - id: generate-password
-      run: echo "::set-output name=password::$(openssl rand -base64 ${{ inputs.length }})"
+      run: echo "name=$(openssl rand -base64 ${{ inputs.length }})" >> $GITHUB_OUTPUT
       shell: bash

--- a/.github/actions/generate-pki/action.yml
+++ b/.github/actions/generate-pki/action.yml
@@ -45,7 +45,7 @@ runs:
         openssl rand -hex 32 > artifact/client.psk
       shell: bash
     - name: Upload PKI as artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.pki-name }}
         path: artifact/

--- a/.github/ci/docker-compose.yml
+++ b/.github/ci/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "2.1"
 services:
   postgres-server:
     image: postgres:latest

--- a/.github/workflows/zabbix-integration.yml
+++ b/.github/workflows/zabbix-integration.yml
@@ -116,6 +116,9 @@ jobs:
       ZBX_TEST_HOST_NAME: CI test host
       ZBX_TEST_ITEM_NAME_PREFIX: CI test item
       ZBX_TEST_ITEM_KEY_PREFIX: ci.test
+      ZBX_TLSCAFILE: "/var/lib/zabbix/enc/ca.crt"
+      ZBX_TLSCERTFILE: "/var/lib/zabbix/enc/localhost.crt"
+      ZBX_TLSKEYFILE: "/var/lib/zabbix/enc/localhost.key"
 
     steps:
       - uses: actions/checkout@v4
@@ -131,9 +134,6 @@ jobs:
         env:
           PGPASSWORD: "${{ needs.temporary-credentials.outputs.postgres_password }}"
           ZBX_ENC_VOLPATH: "${{ github.workspace }}/pki"
-          ZBX_TLSCAFILE: "ca.crt"
-          ZBX_TLSCERTFILE: "localhost.crt"
-          ZBX_TLSKEYFILE: "localhost.key"
 
       - name: Download ${{ env.CI_EXAMPLE_BIN }} binary artifact for integration test
         uses: actions/download-artifact@v4

--- a/.github/workflows/zabbix-integration.yml
+++ b/.github/workflows/zabbix-integration.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - ci
   pull_request:
     branches:
       - master
@@ -18,7 +19,7 @@ jobs:
       postgres_password: ${{ steps.postgres_password.outputs.password }}
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - id: postgres_password
         uses: ./.github/actions/generate-password
       - name: Generate temporary mTLS PKI
@@ -57,12 +58,12 @@ jobs:
             tls: tls_rustls
             async-tls: tls_rustls_tokio
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-      - uses: Swatinem/rust-cache@v1.4.0
+      - uses: Swatinem/rust-cache@v2
 
       # cargo test also builds all examples (that are compatible with the features),
       # so we can run unit tests *and* get the example binary needed for integration
@@ -70,7 +71,7 @@ jobs:
       - name: Run unit tests and build examples
         run: cargo test --verbose --features "${{ env.BUILD_FEATURES }}"
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ env.CI_EXAMPLE_BIN }}-${{ matrix.async }}-${{ matrix.tls }}
           path: target/debug/examples/${{ env.CI_EXAMPLE_BIN }}
@@ -117,10 +118,10 @@ jobs:
       ZBX_TEST_ITEM_KEY_PREFIX: ci.test
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Download mTLS PKI
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: cert-pki
           path: pki
@@ -135,7 +136,7 @@ jobs:
           ZBX_TLSKEYFILE: "localhost.key"
 
       - name: Download ${{ env.CI_EXAMPLE_BIN }} binary artifact for integration test
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.CI_EXAMPLE_BIN }}-${{ matrix.async }}-${{ matrix.tls }}
 

--- a/.github/workflows/zabbix-integration.yml
+++ b/.github/workflows/zabbix-integration.yml
@@ -127,7 +127,7 @@ jobs:
           path: pki
 
       - name: Start job services
-        run: cd .github/ci && docker-compose up --detach
+        run: cd .github/ci && docker compose up --detach
         env:
           PGPASSWORD: "${{ needs.temporary-credentials.outputs.postgres_password }}"
           ZBX_ENC_VOLPATH: "${{ github.workspace }}/pki"
@@ -163,7 +163,7 @@ jobs:
             http://localhost:8080
 
       - name: Get Zabbix Server logs
-        run: cd .github/ci && docker-compose logs zabbix-server
+        run: cd .github/ci && docker compose logs zabbix-server
 
       - name: Reload the Zabbix Server configuration cache
         run: |
@@ -177,8 +177,8 @@ jobs:
             cd .github/ci
             while true
             do
-              # Capture the output of docker-compose to check for success
-              COMPOSE_OUT="$(docker-compose exec -T zabbix-server zabbix_server --runtime-control config_cache_reload 2>&1)"
+              # Capture the output of docker compose to check for success
+              COMPOSE_OUT="$(docker compose exec -T zabbix-server zabbix_server --runtime-control config_cache_reload 2>&1)"
 
               # Display the full output
               echo "$COMPOSE_OUT"
@@ -199,7 +199,7 @@ jobs:
           set +e
 
           # Increase the log level of Zabbix Server Trapper processes, to get useful information in case of error
-          (cd .github/ci && docker-compose exec -T zabbix-server zabbix_server --runtime-control log_level_increase=trapper)
+          (cd .github/ci && docker compose exec -T zabbix-server zabbix_server --runtime-control log_level_increase=trapper)
 
           # Configure TLS command line options
           case '${{ matrix.encryption }}' in
@@ -235,6 +235,6 @@ jobs:
           # If ${{ env.CI_EXAMPLE_BIN }} exited with an error, print the Zabbix Server logs
           if [ $? -ne 0 ]; then
             printf '\n\nzabbix-server container logs:\n\n'
-            (cd .github/ci && docker-compose logs zabbix-server)
+            (cd .github/ci && docker compose logs zabbix-server)
             exit 1
           fi

--- a/script/zabbix_api_setup.py
+++ b/script/zabbix_api_setup.py
@@ -25,7 +25,9 @@ class ZabbixError(Exception):
 
     def __init__(self, response):
         if 'error' not in response:
-            raise RuntimeError('ZabbixError constructed from a non-error response')
+            raise RuntimeError(
+                'ZabbixError constructed from a non-error response'
+            )
 
         message = response['error']['message']
         data = response['error']['data']
@@ -48,7 +50,10 @@ class Zabbix:
         self.token = None
 
     def login(self, username, password):
-        self.token = self.call('user.login', {'user': username, 'password': password})
+        self.token = self.call(
+            'user.login',
+            {'username': username, 'password': password}
+        )
 
     def call(self, method, params):
         operation = {
@@ -58,21 +63,18 @@ class Zabbix:
             'params': params
         }
         self.request_id += 1
-
-        if self.token is not None:
-            operation['auth'] = self.token
-
         data = json.dumps(operation).encode('utf-8')
 
-        request = rq.Request(
-            self.endpoint,
-            data,
-            headers={'Content-Type': 'application/json'}
-        )
+        headers = {'Content-Type': 'application/json'}
+        if self.token is not None:
+            headers['Authorization'] = f"Bearer {self.token}"
+        request = rq.Request(self.endpoint, data, headers)
 
         with rq.urlopen(request) as response:
             if response.status != 200:
-                raise RuntimeError(f"Request failed with status: {response.status}")
+                raise RuntimeError(
+                    f"Request failed with status: {response.status}"
+                )
 
             result = json.load(response)
             if 'error' in result:
@@ -210,7 +212,12 @@ def main():
             identifier='hostid'
         )
 
-        item_valuetypes = {'float': 0, 'character': 1, 'unsigned': 3, 'text': 4}
+        item_valuetypes = {
+            'float': 0,
+            'character': 1,
+            'unsigned': 3,
+            'text': 4
+        }
 
         for item_valuetype, item_valuetype_id in item_valuetypes.items():
             item_name = f"{ZABBIX_ITEM_NAME_PREFIX} - {item_valuetype}"


### PR DESCRIPTION
CI was broken due to Github deprecating older versions of some actions. Also, the Zabbix API has very slightly changed from 5.x to 7.x, so updated integration test scripts to adapt to changes.